### PR TITLE
Make implementer tools hidden by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # openmrs-esm-implementer-tools-app
+
 [![Build Status](https://travis-ci.org/openmrs/openmrs-implementer-tools-app.svg?branch=master)](https://travis-ci.org/openmrs/openmrs-esm-implementer-tools-app)
 
 An [OpenMRS Microfrontend](https://wiki.openmrs.org/display/projects/Frontend+-+SPA+and+Microfrontends).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest --passWithNoTests",
     "start": "webpack-dev-server",
+    "start-https": "webpack-dev-server --https",
     "build": "rimraf dist && concurrently -n webpack,typescript 'webpack --mode=production' 'npm run typescript'",
     "typescript": "tsc",
     "prettier": "prettier 'src/**/*' --write",
@@ -36,7 +37,6 @@
   },
   "homepage": "https://github.com/openmrs/esm-implementer-tools#readme",
   "dependencies": {
-    "@openmrs/esm-api": "^3.0.0",
     "@types/jest": "^26.0.10",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
@@ -50,6 +50,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
+    "@openmrs/esm-api": "^3.0.0",
     "@openmrs/react-root-decorator": "^3.2.0",
     "@testing-library/react": "^10.4.9",
     "babel-eslint": "^10.1.0",

--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import openmrsRootDecorator from "@openmrs/react-root-decorator";
 import Popup from "./popup/popup.component";
 import styles from "./implementer-tools.styles.css";
+import { UserHasAccessReact } from "@openmrs/esm-api";
 
 function Root(props: RootProps) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
@@ -12,7 +13,7 @@ function Root(props: RootProps) {
   }
 
   return (
-    <>
+    <UserHasAccessReact privilege="coreapps.systemAdministration">
       <button
         tabIndex={0}
         onClick={togglePopup}
@@ -21,7 +22,7 @@ function Root(props: RootProps) {
         }`}
       />
       {isPopupOpen && <Popup close={togglePopup} setHasAlert={setHasAlert} />}
-    </>
+    </UserHasAccessReact>
   );
 }
 


### PR DESCRIPTION
### What does this PR do?

It hides the implementer rectangular button at the bottom right corner of the window for non-admin users

### Description of Task completed 

Hide the implementer tools to non-admin users by checking users' privilege to determine whether to show it or hide it.

### Screenshoots

![tools](https://user-images.githubusercontent.com/28008754/94682441-9f8a8880-032d-11eb-8db2-a1f168350ee5.gif)



﻿
