### PR TITLE
MF-312: Implementer should be able to download contents of Temporary Config

### DIFF
--- a/src/configuration/configuration.component.tsx
+++ b/src/configuration/configuration.component.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback } from "react";
+import React from "react";
 import {
   getDevtoolsConfig,
   getAreDevDefaultsOn,
   setAreDevDefaultsOn,
   clearTemporaryConfig,
+  getTemporaryConfig,
 } from "@openmrs/esm-module-config";
 import Switch from "./switch.component";
 import styles from "./configuration.styles.css";
@@ -20,6 +21,12 @@ export default function Configuration(props: ConfigurationProps) {
   );
   const [isUIEditorActive, setIsUIEditorActive] = React.useState(
     getIsUIEditorEnabled()
+  );
+  const tempConfigObjUrl = new Blob(
+    [JSON.stringify(getTemporaryConfig(), undefined, 2)],
+    {
+      type: "application/json",
+    }
   );
 
   const updateConfig = () => {
@@ -61,6 +68,22 @@ export default function Configuration(props: ConfigurationProps) {
           }}
         >
           Clear Temporary Config
+        </button>
+        <button className={styles.downloadButton}>
+          <a
+            className={styles.downloadLink}
+            download="temporary_config.json"
+            href={window.URL.createObjectURL(tempConfigObjUrl)}
+          >
+            <svg
+              className="omrs-icon"
+              fill="rgba(0, 0, 0, 0.54)"
+              style={{ height: "1rem" }}
+            >
+              <use xlinkHref="#omrs-icon-download" />
+            </svg>
+            Download Temporary Config
+          </a>
         </button>
       </div>
       <div className={styles.configContent}>

--- a/src/configuration/configuration.styles.css
+++ b/src/configuration/configuration.styles.css
@@ -21,3 +21,14 @@
   font-family: "monospace";
   font-size: "12pt";
 }
+
+.downloadButton {
+  display: flex;
+  align-items: center;
+}
+
+.downloadLink {
+  display: inline-flex;
+  text-decoration: none;
+  color: #000;
+}


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-312

Adds a download button at the top of the implementer tools panel which when clicked allows the user to download a JSON file with the contents of the temporary config.

![Kapture 2020-10-07 at 11 05 16](https://user-images.githubusercontent.com/8509731/95304299-14f5dc00-088d-11eb-98b2-13a92c863883.gif)

