### PR TITLE
Enable concept lookup in implementer tools panel

### DIFF
--- a/src/configuration/concept-search.resource.tsx
+++ b/src/configuration/concept-search.resource.tsx
@@ -1,0 +1,13 @@
+import { openmrsFetch } from "@openmrs/esm-api";
+
+export function fetchConceptByUuid(conceptUuid: string) {
+  return openmrsFetch(`/ws/rest/v1/concept/${conceptUuid}`, {
+    method: "GET",
+  });
+}
+
+export function performConceptSearch(query: string) {
+  return openmrsFetch(`/ws/rest/v1/concept/?q=${query}`, {
+    method: "GET",
+  });
+}

--- a/src/configuration/config-tree.component.tsx
+++ b/src/configuration/config-tree.component.tsx
@@ -13,13 +13,19 @@ export default function ConfigTree({ config, path = [] }: ConfigTreeProps) {
         Object.entries(config).map(([key, value]) => {
           const thisPath = path.concat([key]);
           return (
-            <div key={key} style={{ margin: `0.25em 0 0.25em 3em` }}>
+            <div key={key} style={{ margin: `0.25em 0em 0.25em 3em` }}>
               {isOrdinaryObject(value) ? (
                 <div>
                   {key}: <ConfigTree config={value} path={thisPath} />
                 </div>
               ) : (
-                <div style={{ display: "flex" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    flexFlow: "row wrap",
+                    alignItems: "center",
+                  }}
+                >
                   {key}: <EditableValue path={thisPath} value={value} />
                 </div>
               )}

--- a/src/configuration/editable-value.component.tsx
+++ b/src/configuration/editable-value.component.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
+import { debounce, isEqual } from "lodash";
 import { setTemporaryConfigValue } from "@openmrs/esm-module-config";
 import styles from "./editable-value.styles.css";
 import ValueEditor from "./value-editor";
 import { useGlobalState } from "../global-state";
-import { isEqual } from "lodash";
+import {
+  fetchConceptByUuid,
+  performConceptSearch,
+} from "./concept-search.resource";
 
 interface EditableValueProps {
   path: string[];
@@ -18,6 +22,12 @@ export default function EditableValue({ path, value }: EditableValueProps) {
     "configPathBeingEdited"
   );
   const activeConfigPath = useRef<HTMLButtonElement>(null);
+  const [isSearchPanelOpen, setIsSearchPanelOpen] = useState(false);
+  const [activeConceptUuid, setActiveConceptUuid] = useState<any>("");
+  const [conceptName, setConceptName] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [searchResults, setSearchResults] = useState([]);
+  const searchTimeoutInMs = 300;
 
   const closeEditor = () => {
     setEditing(false);
@@ -31,40 +41,146 @@ export default function EditableValue({ path, value }: EditableValueProps) {
     }
   };
 
+  const toggleSearchPanel = () => {
+    setIsSearchPanelOpen(!isSearchPanelOpen);
+  };
+
+  const handleSearchTermChange = debounce((searchTerm) => {
+    setSearchTerm(searchTerm);
+  }, searchTimeoutInMs);
+
+  const handleUuidChange = (conceptUuid) => {
+    setTemporaryConfigValue(path, conceptUuid);
+    setActiveConceptUuid(conceptUuid);
+    resetSearch();
+    toggleSearchPanel();
+  };
+
+  const resetSearch = () => {
+    setSearchTerm("");
+    setSearchResults([]);
+  };
+
   useEffect(() => {
     if (isEqual(configPathBeingEdited, path)) {
       focusOnConfigPathBeingEdited();
     }
   }, [configPathBeingEdited]);
 
+  useEffect(() => {
+    if (activeConceptUuid) {
+      const conceptString = activeConceptUuid;
+
+      fetchConceptByUuid(conceptString).then(({ data }) => {
+        setConceptName(data.name.display);
+      });
+    }
+  }, [activeConceptUuid]);
+
+  useEffect(() => {
+    const ac = new AbortController();
+
+    if (searchTerm && searchTerm.length >= 2) {
+      performConceptSearch(searchTerm).then(({ data: { results } }) => {
+        setSearchResults(results.slice(0, 9));
+      });
+    } else {
+      setSearchResults([]);
+    }
+    return () => ac.abort();
+  }, [searchTerm]);
+
   return (
-    <div style={{ display: "flex" }}>
-      {editing ? (
-        <ValueEditor
-          valueString={valueString ?? JSON.stringify(value)}
-          handleClose={closeEditor}
-          handleSave={(val) => {
-            try {
-              const result = JSON.parse(val);
-              setTemporaryConfigValue(path, result);
-              setValueString(val);
-              closeEditor();
-            } catch (e) {
-              console.warn(e);
-              setError("That's not formatted quite right. Try again.");
-            }
-          }}
-        />
-      ) : (
-        <button
-          className={styles.secretButton}
-          onClick={() => setEditing(true)}
-          ref={activeConfigPath}
-        >
-          {valueString ?? JSON.stringify(value)}
-        </button>
-      )}
-      {error && <div className={styles.error}>{error}</div>}
-    </div>
+    <>
+      <div style={{ display: "flex" }}>
+        {editing ? (
+          <ValueEditor
+            valueString={valueString ?? JSON.stringify(value)}
+            handleClose={closeEditor}
+            handleSave={(val) => {
+              try {
+                const result = JSON.parse(val);
+                setTemporaryConfigValue(path, result);
+                setValueString(val);
+                closeEditor();
+              } catch (e) {
+                console.warn(e);
+                setError("That's not formatted quite right. Try again.");
+              }
+            }}
+          />
+        ) : (
+          <button
+            className={styles.secretButton}
+            onClick={() => setEditing(true)}
+            ref={activeConfigPath}
+          >
+            {activeConceptUuid
+              ? `"${activeConceptUuid}"`
+              : valueString ?? JSON.stringify(value)}
+          </button>
+        )}
+        {error && <div className={styles.error}>{error}</div>}
+        {value && typeof value === "string" && path[1]?.match(/concepts/) && (
+          <span
+            style={{
+              backgroundColor: "#edf2f7",
+              borderRadius: "9999px",
+              color: "#1a202c",
+              padding: "0.05rem 0.5rem",
+              margin: "0.5rem",
+              height: "1rem",
+            }}
+            onClick={() => {
+              setActiveConceptUuid(valueString ?? value);
+              toggleSearchPanel();
+              resetSearch();
+            }}
+          >
+            {isSearchPanelOpen ? `${conceptName}` : "C"}
+          </span>
+        )}
+      </div>
+      <div style={{ display: "flex", flex: "100%", flexFlow: "columnWrap" }}>
+        {isSearchPanelOpen && (
+          <div className={styles.autocomplete}>
+            <input
+              type="text"
+              autoComplete="off"
+              autoCapitalize="off"
+              aria-autocomplete="list"
+              role="combobox"
+              aria-label="Look up concept by name"
+              placeholder="Look up concept by name"
+              autoFocus
+              onChange={($event) => {
+                handleSearchTermChange($event.target.value);
+              }}
+            />
+            <div>
+              <ul role="listbox">
+                {!!searchResults.length &&
+                  searchResults.map((concept: any) => (
+                    <li
+                      key={concept.uuid}
+                      role="option"
+                      style={{ padding: "5px" }}
+                      onClick={() => {
+                        handleUuidChange(concept.uuid);
+                      }}
+                      aria-selected="true"
+                    >
+                      {concept.display}
+                    </li>
+                  ))}
+                {searchTerm && searchResults && !searchResults.length && (
+                  <li>No matching results found.</li>
+                )}
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/src/configuration/editable-value.styles.css
+++ b/src/configuration/editable-value.styles.css
@@ -11,3 +11,39 @@
   color: orange;
   font-size: 11pt;
 }
+
+.autocomplete,
+.autocomplete > [role="combobox"] {
+  position: relative;
+  width: 60%;
+}
+
+.autocomplete > input {
+  width: 60%;
+}
+
+.autocomplete [role="listbox"] {
+  width: 60%;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-flow: column wrap;
+  background-color: whitesmoke;
+  color: #fff;
+}
+
+.autocomplete li {
+  line-height: 0.75rem;
+  padding: 0.5em;
+  display: block;
+  border-bottom: 0.125rem solid #718096;
+  outline: 0;
+  margin: 0;
+  color: #000;
+}
+
+.autocomplete [role="option"]:hover {
+  background-color: #38a169;
+  border-color: #38a169;
+  color: #f7fafc;
+}


### PR DESCRIPTION
Enables looking up concepts in the implementer tools for concept values in the config schema. Any changes are persisted to the temporary config.

![Kapture 2020-10-12 at 23 17 40](https://user-images.githubusercontent.com/8509731/95787078-741a7d00-0ce1-11eb-9c89-68157ef04a7e.gif)
